### PR TITLE
Only look for the first rust version

### DIFF
--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -26,7 +26,7 @@ jobs:
         - name: Get rust version from code
           id: rust-version
           run: |
-            echo "app_version=$(head -6 $CARGO_TOML_FILE | grep version | sed 's/"/ /g' | awk '{print $3}')" >> $GITHUB_OUTPUT
+            echo "app_version=$(head -6 $CARGO_TOML_FILE | grep version -m 1 | sed 's/"/ /g' | awk '{print $3}')" >> $GITHUB_OUTPUT
           env:
             CARGO_TOML_FILE: ${{ inputs.cargo_toml_dir }}/Cargo.toml
         

--- a/sample_rust/Cargo.toml
+++ b/sample_rust/Cargo.toml
@@ -2,3 +2,4 @@
 name = "workflows"
 version = "0.19.0"
 edition = "2021"
+rust-version = "1.65"


### PR DESCRIPTION
This is to avoid duplicate with key “rust-version” that specifies the toolchain