### PR TITLE
Add toml file version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
       version: ${{ needs.version.outputs.tag }}
       cargo_toml_dir: sample_rust
   
+  check-toml-version:
+    needs: version
+    uses: ./.github/workflows/toml-version.yml
+    with: 
+      version: ${{ needs.version.outputs.tag }}
+      toml_file: sample_toml/pyproject.toml
+
   check-kicad-version:
     needs: version
     uses: ./.github/workflows/kicad-version.yml

--- a/.github/workflows/toml-version.yml
+++ b/.github/workflows/toml-version.yml
@@ -1,0 +1,50 @@
+name: Check version in TOML file against TAG version
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "The TAG version string for this release"
+        required: true
+        type: string
+      toml_file:
+        description: "The path and name of the *.toml file"
+        required: true
+        type: string
+    
+jobs:
+    toml-version:
+        runs-on: ubuntu-24.04
+        steps:
+        - uses: actions/checkout@v4
+
+        - name: Strip v from TAG
+          run: |
+            TAG=${{ inputs.version }}
+            echo "EXPECTED_VERSION=${TAG#v}" >> $GITHUB_ENV
+
+        - name: Get toml version from code
+          id: toml-version
+          run: |
+            echo "app_version=$(head -10 $CARGO_TOML_FILE | grep version -m 1 | sed 's/"/ /g' | awk '{print $3}')" >> $GITHUB_OUTPUT
+          env:
+            CARGO_TOML_FILE: ${{ inputs.toml_file }}
+        
+        - name: Display versions
+          run: |
+            echo "TOML app version: '${{ steps.toml-version.outputs.app_version }}'"
+            echo "Expected version: '$EXPECTED_VERSION'"
+
+        - name: Check toml version
+          run: |
+            if [[ "${{ steps.toml-version.outputs.app_version }}" != "$EXPECTED_VERSION" ]]; then
+                echo "TOML app version mismatch: ${{ steps.toml-version.outputs.app_version }} != $EXPECTED_VERSION"
+                if [[ "$EXPECTED_VERSION" == "" ]]; then
+                    echo "This is a pre-release version, so this is expected."
+                    exit 0
+                else
+                    echo "This is a release version, so this is unexpected."
+                    exit 1
+                fi
+            fi
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Shared Workflows's documentation
    introduction
    version
    rust-version
+   toml-version
    kicad-version
    kicad-release
    docs

--- a/docs/toml-version.md
+++ b/docs/toml-version.md
@@ -1,0 +1,34 @@
+# TOML Version
+
+The **TOML Version Check** workflow `toml-version.yml` checks that the TOML version used in the project is the same as the one used for releases using the `version.yml` workflow.
+
+## Pre-requisites
+
+1. The workflow expects a `.toml` file in the provided `toml_file` variable (including path to) to check the TOML version
+2. The workflow expects a the `tag` output of the `version.yml` workflow.
+
+## Operation
+
+You need to run the `version.yml` workflow before this one, and provide the `tag` output as input.
+
+The workflow will check the TOML version against the `tag` and:
+
+- succeed if the TOML version is the same as the `tag`
+- if the TOML version is different from the `tag`:
+  - fail if it's a release build
+  - succeed with a warning if it's a development build
+
+Example:
+
+```yaml
+jobs:
+  version:
+    uses: nxlabs-ch/shared-workflows/.github/workflows/version.yml@main
+
+  check-toml-version:
+    needs: version
+    uses: nxlabs-ch/shared-workflows//.github/workflows/toml-version.yml@main
+    with: 
+      version: ${{ needs.version.outputs.tag }}
+      toml_file: my_module/pyproject.toml
+```

--- a/sample_toml/pyproject.toml
+++ b/sample_toml/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tx-test-python"
+version = "0.19.1"
+description = "A python tool with a GUI to measure and accept transducers on the factory line"
+readme = "README.md"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "kivy>=2.3.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
This is a generalisation of rust-version check that uses a Cargo.toml file.
Here it can be any toml file with a version key in the first 10 lines.